### PR TITLE
Add command to fix Drupal permissions

### DIFF
--- a/.docksal/commands/fix-perms
+++ b/.docksal/commands/fix-perms
@@ -22,8 +22,10 @@ SITEDIR_PATH="${DOCROOT_PATH}/sites/${SITE_DIRECTORY}"
 # Fix file/folder permissions
 fix_permissions ()
 {
-	echo "Making site directory writable..."
+	echo "Making ${SITEDIR_PATH} writable..."
 	chmod 755 "${SITEDIR_PATH}"
+	echo "Making ${SITEDIR_PATH}/* writable..."  
+	chmod 755 "${SITEDIR_PATH}"/*
 }
 
 #-------------------------- END: Functions --------------------------------

--- a/.docksal/commands/fix-perms
+++ b/.docksal/commands/fix-perms
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+#: exec_target = cli
+
+## Fix Drupal site directory permissions
+##
+## Usage: fin fix-perms
+
+# Abort if anything fails
+set -e
+
+#-------------------------- Settings --------------------------------
+
+# PROJECT_ROOT and DOCROOT are set as env variables in cli
+SITE_DIRECTORY="default"
+DOCROOT_PATH="${PROJECT_ROOT}/${DOCROOT}"
+SITEDIR_PATH="${DOCROOT_PATH}/sites/${SITE_DIRECTORY}"
+
+#-------------------------- END: Settings --------------------------------
+
+#-------------------------- Functions --------------------------------
+# Fix file/folder permissions
+fix_permissions ()
+{
+	echo "Making site directory writable..."
+	chmod 755 "${SITEDIR_PATH}"
+}
+
+#-------------------------- END: Functions --------------------------------
+
+#-------------------------- Execution --------------------------------
+fix_permissions
+
+#-------------------------- END: Execution --------------------------------


### PR DESCRIPTION
## Description
> As a developer, want to be able to easily modify my `settings.php` and other files.

This exists in `init-site` but is useful to run on it's own. This PR breaks the command out into its own command and replaces its use in `init-site` so we're DRY.

## Acceptance Criteria


## Affected URL
NA

## Related Tickets
NA

## Steps to Validate
1. `fin fix-perms`
1. `ls -la sites/default`
1. `fin init-site` and see it doesn't fail.


## Deploy Notes
NA