### PR TITLE
Copy settings.php if we're local

### DIFF
--- a/.docksal/commands/init-site
+++ b/.docksal/commands/init-site
@@ -52,6 +52,11 @@ site_install ()
 {
 	cd $DOCROOT_PATH
 
+    if [[ $HOSTNAME == "cli" ]]; then
+      # Add settings.local.php if it doesn't already exist and we're in docksal. This will get ignored by git.
+	  copy_settings_file $DOCROOT_PATH/sites/example.settings.local.php $SITEDIR_PATH/settings.local.php
+    fi
+
 	# We disable email sending here so site-install does not return an error
 	PHP_OPTIONS="-d sendmail_path=`which true`" drush site-install -y --site-name='My Drupal 8 Site' --sites-subdir="default"
 }


### PR DESCRIPTION
## Description
> As a developer, I want to have pre-configured local settings.

Adds some logic to `fin init-site` to copy the default `settings.local.php` to the site directory on initial setup. This file is already `.gitignore`ed, so it won't be committed, but this will help devs have a consistent dev environment.

Interestingly, this might soon be able to be done in `drupal-scaffold`, but the PR is still WIP https://github.com/drupal-composer/drupal-scaffold/pull/58

## Acceptance Criteria


## Affected URL
NA

## Related Tickets
NA

## Steps to Validate
1. `fin init-site`
1. See that `settings.local.php` exists.


## Deploy Notes
NA