### PR TITLE
Updating Docksal and Front end build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           path: web/themes/custom/site_theme/
       - run:
           name: Compile CSS and JS files
-          command: gulp
+          command: gulp build
           path: web/themes/custom/site_theme/
       - run:
           name: Remove node_modules

--- a/.docksal/docksal.env
+++ b/.docksal/docksal.env
@@ -10,7 +10,7 @@ DOCKSAL_STACK=default
 # This will prevent images from being updated when Docksal is updated
 WEB_IMAGE='docksal/web:2.1-apache2.4'
 DB_IMAGE='docksal/db:1.1-mysql-5.7'
-CLI_IMAGE='docksal/cli:2.1-php7.1'
+CLI_IMAGE='docksal/cli:2.6-php7.2'
 
 # Docksal configuration.
 DOCROOT=web

--- a/.docksal/docksal.yml
+++ b/.docksal/docksal.yml
@@ -28,6 +28,9 @@ services:
       - LANGUAGE=en_US.UTF-8
     volumes:
       - ${PROJECT_ROOT}/.docksal/etc/drush:/etc/drush:ro
+    ports:
+      - "3050:3050"
+      - "3051:3051"
 
   # Fake email
   mail:

--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ Thumbs.db
 
 # Ignore composer bin directory
 /bin
+*.map

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Features:
 
 ### Step #1: Docksal environment setup
 
-**This is a one time setup - skip this if you already have a working Docksal environment.**  
+**This is a one time setup - skip this if you already have a working Docksal environment.**
 
 Follow [Docksal install instructions](https://docs.docksal.io/getting-started/setup/)
 
@@ -43,9 +43,9 @@ Follow [Docksal install instructions](https://docs.docksal.io/getting-started/se
 
 When the automated install is complete the command line output will display the admin username and password.
 
-## Easier setup with 'fin init'
+## Easier setup with `fin init`
 
-Site provisioning can be automated using `fin init`, which calls the shell script in [.docksal/commands/init](.docksal/commands/init).  
+Site provisioning can be automated using `fin init`, which calls the shell script in [.docksal/commands/init](.docksal/commands/init).
 This script is meant to be modified per project. The one in this repo will give you a good example of advanced init script.
 
 Some common tasks that can be handled by the init script:
@@ -55,3 +55,52 @@ Some common tasks that can be handled by the init script:
 - compile Sass
 - run DB updates, revert features, clear caches, etc.
 - enable/disable modules, update variables values
+
+## Installing Modules
+
+Modules are installed using composer. The process for installing a module would be the following:
+
+```
+fin composer require [package]
+```
+
+The standard composer command is used but with the Docksal specific command `fin` prepended to the beginning.
+
+## Theme
+
+The theme is based off of the Zurb Foundation framework. Gulp is installed and is helping with the compilation of the
+sass to css. Additionally it is also helping with the minification of the javascript and css to make the code as minimal
+as possible.
+
+The theme included is located within `web/sites/themes/custom/site_theme`.
+
+You should clone that, rename, and update the names in the file names and in the files.
+
+### Gulp Commands
+
+The following gulp tasks are available:
+
+Command | Description
+--------|------------
+`sass` | One time compiles sass to css
+`watch` | Watches for changes with in the sass and lib folders and then runs the compilation and uglification
+`uglify` | Compresses all javascript files within the lib folder and minifies the code. The output is added to the js folder.
+`imagemin` | Compresses the images within the image folder
+`build` | Runs `sass` and `uglify`.  Used in the CircleCI automation
+
+## Docksal Commands
+
+The following commands are available with Docksal and should be prefixed with the command `fin`
+
+Command | Description
+--------|------------
+`composer` | Composer wrapper that executes within the CLI container
+`drupal-cli` | Drupali CLI wrapper
+`gulp` | Gulp Wrapper that runs within the theme web/themes/custom/site_theme
+`init` | Init Command that starts the project from scratch.
+`init-site` | Init Site Command that runs the site install and/or then runs the refresh command
+`npm` | NPM wrapper
+`refresh` | Will execute a drush sql-dump from the remote server. **NOT SET UP CURRENTLY**
+`site-build` | Will run all of the necessary steps for `npm install` and `gulp sass`
+`test` | Test to confirm the site is running
+

--- a/web/themes/custom/site_theme/.gitignore
+++ b/web/themes/custom/site_theme/.gitignore
@@ -3,3 +3,4 @@ css/*
 js/*
 !js/.gitkeep
 node_modules
+*css.map

--- a/web/themes/custom/site_theme/package.json
+++ b/web/themes/custom/site_theme/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "gulp-autoprefixer": "^3.0.2",
-    "gulp": "^4.0",
+    "gulp": "^3.9.1",
     "gulp-imagemin": "^2.3.0",
     "gulp-sass": "^4",
     "gulp-uglifyjs": "^0.6.2",
@@ -17,7 +17,11 @@
     "gulp-clean-css": "^2.0.12",
     "gulp-livereload": "^3.8.1",
     "gulp-sass-glob": "^1.0.6",
-    "gulp-sourcemaps": "^1.6.0"
+    "gulp-sourcemaps": "^1.6.0",
+    "browser-sync": "^2.26.3",
+    "gulp-rename": "^1.4.0",
+    "breakpoint-sass": "^2.7.1",
+    "gulp-strip-css-comments": "^2.0.0"
   },
   "dependencies": {
     "font-awesome": "^4.7.0",


### PR DESCRIPTION
## Description
We should update our base starter repo with the changes we needed to make while implementing it on Dvele. https://github.com/kanopi/dvele/pull/5

> This PR makes some updates to the local environment:

- Updates the gulp task
- Adds ports to docksal for browsersync
- This also bumps php to 7.2 in docksal
- removes font-awesome
- Creates a "css.dev" file for checking complied CSS diffs. 

## Acceptance Criteria
- Gulp commands should run without error
- browsersync should work on http://sitename.docksal:3050
- local environment should be PHP 7.2 

## Affected URL
N/A

## Related Tickets
N/A

## Steps to Validate
1. Run various gulp commands and ensure that there are no errors
1. test for the local php version `fin exec php -v` - it should be 7.2.x
1. browsersync should be running on http://dvele.docksal:3050

## Deploy Notes
- Be sure to re-run `fin npm install`